### PR TITLE
fixes for lts v1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,11 +15,20 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.10'
           - '1.11'
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
+        allow_failure: [false]
+        include:
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -25,12 +25,12 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 [compat]
 Accessors = "0.1.42"
 Crayons = "4.1.1"
-Dates = "1.11.0"
+Dates = "1.10, 1.11.0"
 NaNStatistics = "0.6.50"
 Pkg = "1.10.0"
 Reexport = "1.2.2"
 TypedTables = "1.4.6"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/SindbadSetup/src/setupExperimentInfo.jl
+++ b/lib/SindbadSetup/src/setupExperimentInfo.jl
@@ -104,8 +104,7 @@ Saves or skips saving the experiment configuration to a file.
 function saveInfo end
 
 function saveInfo(info, ::DoSaveInfo)
-    info_path = joinpath(info.output.dirs.settings, "info.jld
-    2")
+    info_path = joinpath(info.output.dirs.settings, "info.jld2")
     showInfo(saveInfo, @__FILE__, @__LINE__, "saving info to `$(info_path)`")
     @save info_path info
     return nothing

--- a/lib/SindbadSetup/src/setupHybridML.jl
+++ b/lib/SindbadSetup/src/setupHybridML.jl
@@ -152,7 +152,7 @@ function setHybridInfo(info::NamedTuple)
     info = setTupleSubfield(info, :hybrid, (:replace_value_for_gradient, info.temp.helpers.numbers.num_type(replace_value_for_gradient)))
 
 
-    covariates_path = getAbsDataPath(info, info.settings.hybrid.covariates.path)
+    covariates_path = getAbsDataPath(info.temp, info.settings.hybrid.covariates.path)
     covariates = (; path=covariates_path, variables=info.settings.hybrid.covariates.variables)
     info = setTupleSubfield(info, :hybrid, (:covariates, covariates))
     info = setTupleSubfield(info, :hybrid, (:random_seed, info.settings.hybrid.random_seed))

--- a/lib/SindbadSetup/src/setupOutput.jl
+++ b/lib/SindbadSetup/src/setupOutput.jl
@@ -255,9 +255,8 @@ Saves a copy of the experiment settings to the output folder.
 function saveExperimentSettings(info)
     sindbad_experiment = info.temp.experiment.dirs.sindbad_experiment
     showInfo(saveExperimentSettings, @__FILE__, @__LINE__, "saving Experiment JSON Settings to : $(info.output.dirs.settings)")
-    destination_experiment_file = last(split(last(split(sindbad_experiment, path_separator)), "/"))
     cp(sindbad_experiment,
-        joinpath(info.output.dirs.settings, destination_experiment_file);
+        joinpath(info.output.dirs.settings, split(sindbad_experiment, path_separator)[end]);
         force=true)
     for k ∈ keys(info.settings.experiment.basics.config_files)
         v = getfield(info.settings.experiment.basics.config_files, k)

--- a/lib/SindbadSetup/src/setupOutput.jl
+++ b/lib/SindbadSetup/src/setupOutput.jl
@@ -255,6 +255,7 @@ Saves a copy of the experiment settings to the output folder.
 function saveExperimentSettings(info)
     sindbad_experiment = info.temp.experiment.dirs.sindbad_experiment
     showInfo(saveExperimentSettings, @__FILE__, @__LINE__, "saving Experiment JSON Settings to : $(info.output.dirs.settings)")
+    mkpath(dirname(joinpath(info.output.dirs.settings, split(sindbad_experiment, path_separator)[end]))) # create output directory if it does not exist
     cp(sindbad_experiment,
         joinpath(info.output.dirs.settings, split(sindbad_experiment, path_separator)[end]);
         force=true)

--- a/lib/SindbadSetup/src/setupOutput.jl
+++ b/lib/SindbadSetup/src/setupOutput.jl
@@ -255,9 +255,9 @@ Saves a copy of the experiment settings to the output folder.
 function saveExperimentSettings(info)
     sindbad_experiment = info.temp.experiment.dirs.sindbad_experiment
     showInfo(saveExperimentSettings, @__FILE__, @__LINE__, "saving Experiment JSON Settings to : $(info.output.dirs.settings)")
-    mkpath(dirname(joinpath(info.output.dirs.settings, split(sindbad_experiment, path_separator)[end]))) # create output directory if it does not exist
+    destination_experiment_file = last(split(last(split(sindbad_experiment, path_separator)), "/"))
     cp(sindbad_experiment,
-        joinpath(info.output.dirs.settings, split(sindbad_experiment, path_separator)[end]);
+        joinpath(info.output.dirs.settings, destination_experiment_file);
         force=true)
     for k ∈ keys(info.settings.experiment.basics.config_files)
         v = getfield(info.settings.experiment.basics.config_files, k)

--- a/lib/SindbadSetup/src/setupParameters.jl
+++ b/lib/SindbadSetup/src/setupParameters.jl
@@ -75,7 +75,8 @@ function getParameters(selected_models::Tuple, num_type, model_timestep; return_
     upper = [constrains[i][2] for i in 1:nbounds]
     
     model = [Symbol(supertype(getproperty(Models, m))) for m in model_approach]
-    name_full = [join((model[i], name[i]), ".") for i in 1:nbounds]
+    model_str = string.(model)
+    name_full = [join((last(split(model_str[i], ".")), name[i]), ".") for i in 1:nbounds]
     approach_func = [getfield(Models, m) for m in model_approach]
     model_prev = model_approach[1]
     m_id = findall(x-> x==model_prev, model_names_list)[1]


### PR DESCRIPTION
This PR includes several fixes:

- [x] proper lts support for v1.10
- [x] CI actions for lts and nightly
- [x] fixes info.jld2 name
- [x] in windows, it makes sure the `settings` directory is available before copying files into it.
- [x] removes `Sindbad.Models` from full name, otherwise  `missing_parameters = filter(x -> !(x in parameter_table_all.name_full), parameter_list)` in the function `getOptimizationParametersTable` will not work properly.
- [x] small fix for info.temp in `setHybridInfo`.

A different issue that needs fixing is to also do a unique `info.jld2` file per run, maybe adding a time stamp?
```sh
info_$(now())_rand_id_$(rand(1:1000)).jld2
```
 The issue is that when running an `n-fold` experiment from time to time a write/read error pops up if several process are trying to do the same(write) a the same time, resulting in a failed job. @dr-ko thoughts? 